### PR TITLE
Add new `lv_example` directive that links to interactive examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /html
 /latex
 LVGL.pdf
+__pycache__

--- a/_ext/lv_example.py
+++ b/_ext/lv_example.py
@@ -1,0 +1,37 @@
+from docutils.parsers.rst import Directive
+from docutils import nodes
+from docutils.parsers.rst.directives.images import Image
+from sphinx.directives.code import LiteralInclude
+import os
+
+class LvExample(Directive):
+    required_arguments = 3
+    def run(self):
+        example_path = self.arguments[0]
+        example_name = os.path.split(example_path)[1]
+        node_list = []
+
+        paragraph_node = nodes.raw(text=f"<iframe class='lv-example' src='https://lvgl.github.io/lv_examples/{example_name}/?w=320&h=240'></iframe>", format='html')
+        toggle = nodes.container('', literal_block=False, classes=['toggle'])
+        header = nodes.container('', literal_block=False, classes=['header'])
+        toggle.append(header)
+        example_file = os.path.abspath("lv_examples/src/" + example_path + ".c")
+
+        with open(example_file) as f:
+            contents = f.read()
+            literal_list = nodes.literal_block(contents, contents)
+            literal_list['language'] = self.arguments[2]
+        toggle.append(literal_list)
+        header.append(nodes.paragraph(text="code"))
+        node_list.append(paragraph_node)
+        node_list.append(toggle)
+        return node_list
+
+def setup(app):
+    app.add_directive("lv_example", LvExample)
+
+    return {
+        'version': '0.1',
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/_ext/lv_example.py
+++ b/_ext/lv_example.py
@@ -11,6 +11,7 @@ class LvExample(Directive):
         example_name = os.path.split(example_path)[1]
         node_list = []
 
+        env = self.state.document.settings.env
         paragraph_node = nodes.raw(text=f"<iframe class='lv-example' src='https://lvgl.github.io/lv_examples/{example_name}/?w=320&h=240'></iframe>", format='html')
         toggle = nodes.container('', literal_block=False, classes=['toggle'])
         header = nodes.container('', literal_block=False, classes=['header'])
@@ -23,7 +24,8 @@ class LvExample(Directive):
             literal_list['language'] = self.arguments[2]
         toggle.append(literal_list)
         header.append(nodes.paragraph(text="code"))
-        node_list.append(paragraph_node)
+        if env.app.tags.has('html'):
+            node_list.append(paragraph_node)
         node_list.append(toggle)
         return node_list
 

--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -47,3 +47,12 @@ td {
 .home-img:hover {
   transform: translate(0, -10px);
 }
+
+.lv-example {
+  border: none;
+  outline: none;
+  padding: none;
+  display: block;
+  width: 320px;
+  height: 240px;
+}

--- a/conf.py
+++ b/conf.py
@@ -17,9 +17,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+sys.path.insert(0, os.path.abspath('./_ext'))
 
 import recommonmark
 from recommonmark.transform import AutoStructify
@@ -40,6 +40,7 @@ extensions = ['sphinx.ext.autodoc',
     'recommonmark',
     'sphinx_markdown_tables',
     'breathe',
+    'lv_example'
     ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/conf.py
+++ b/conf.py
@@ -39,7 +39,7 @@ extensions = ['sphinx.ext.autodoc',
     'sphinx.ext.todo',
     'recommonmark',
     'sphinx_markdown_tables',
-    'breathe',
+#    'breathe',
     'lv_example'
     ]
 


### PR DESCRIPTION
This PR changes the example system to use a single directive which is responsible for loading the code file and also embedding an iframe that points to an Emscripten example.

It also requires lvgl/lv_examples#77 to be merged.