### PR TITLE
Update roller.md

### DIFF
--- a/widgets/roller.md
+++ b/widgets/roller.md
@@ -19,7 +19,7 @@ The selected option in the middle can be referenced with `LV_ROLLER_PART_SELECTE
 ## Usage
 
 ### Set options
-The options are passed to the Roller as a string with `lv_roller_set_options(roller, options, LV_ROLLER_MODE_NORMAL/INFINITE)`. The options should be separated by `\n`. For example: `"First\nSecond\nThird"`.
+The options are passed to the Roller as a string with `lv_roller_set_options(roller, options, LV_ROLLER_MODE_NORMAL/INIFINITE)`. The options should be separated by `\n`. For example: `"First\nSecond\nThird"`.
 
 `LV_ROLLER_MODE_INIFINITE` make the roller circular.
 


### PR DESCRIPTION
Fix roller mode typo in set options

Acutally I'm not sure whether this is intended but from my point of view it should be ` LV_ROLLER_MODE_INFINITE` and not `LV_ROLLER_MODE_INIFINITE` (but that's how it is implemented currently). 

What is your opinion?